### PR TITLE
refactor: sort imports roughly by type

### DIFF
--- a/src/components/AssetDiff.tsx
+++ b/src/components/AssetDiff.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import {DiffFromTo} from 'sanity'
-import {Asset} from '../types'
 import {Flex, Text, Stack} from '@sanity/ui'
+
+import type {Asset} from '../types'
 
 type Props = {
   value: Asset | undefined

--- a/src/components/AssetPreview.tsx
+++ b/src/components/AssetPreview.tsx
@@ -1,12 +1,12 @@
-import {Box, Flex, Text, Theme, useTheme} from '@sanity/ui'
-import {DurationLine, InfoLine} from './File.styled'
-
-import {Asset} from '../types'
 import React from 'react'
-import VideoPlayer from './VideoPlayer'
 import prettyBytes from 'pretty-bytes'
 import prettyMilliseconds from 'pretty-ms'
 import styled from 'styled-components'
+import {Box, Flex, Text, Theme, useTheme} from '@sanity/ui'
+
+import {Asset} from '../types'
+import {DurationLine, InfoLine} from './File.styled'
+import VideoPlayer from './VideoPlayer'
 
 type SanityTheme = Theme['sanity']
 

--- a/src/components/DialogHeader.tsx
+++ b/src/components/DialogHeader.tsx
@@ -1,7 +1,6 @@
-import {useCallback} from 'react'
+import React, {useCallback} from 'react'
 import {Box, Flex, Button} from '@sanity/ui'
 import {LaunchIcon} from '@sanity/icons'
-import React from 'react'
 
 interface Props {
   title: string

--- a/src/components/File.tsx
+++ b/src/components/File.tsx
@@ -1,11 +1,11 @@
-import {Asset, ShopifyFile} from '../types'
-import {DurationLine, InfoLine, Root} from './File.styled'
 import React, {useCallback, useRef} from 'react'
 import {Text, useTheme} from '@sanity/ui'
-
-import {extractName} from '../utils/helpers'
 import prettyBytes from 'pretty-bytes'
 import prettyMilliseconds from 'pretty-ms'
+
+import {extractName} from '../utils/helpers'
+import {Asset, ShopifyFile} from '../types'
+import {DurationLine, InfoLine, Root} from './File.styled'
 
 type Props = {
   data: ShopifyFile

--- a/src/components/ShopifyAssetInput.tsx
+++ b/src/components/ShopifyAssetInput.tsx
@@ -1,11 +1,11 @@
+import React from 'react'
+import {ErrorOutlineIcon} from '@sanity/icons'
 import {Button, Card, Flex, Grid, Inline, Stack, Text} from '@sanity/ui'
 import {ObjectInputProps, PatchEvent, unset} from 'sanity'
 import {useCallback, useState} from 'react'
 
 import {Asset} from '../types'
 import AssetPreview from './AssetPreview'
-import {ErrorOutlineIcon} from '@sanity/icons'
-import React from 'react'
 import ShopifyAssetPicker from './ShopifyAssetPicker'
 import ShopifyIcon from './ShopifyIcon'
 

--- a/src/components/ShopifyAssetPicker.tsx
+++ b/src/components/ShopifyAssetPicker.tsx
@@ -1,16 +1,16 @@
-import {Asset, PageInfo, ShopifyAPIResponse, ShopifyFile} from '../types'
 import {BehaviorSubject, Subscription} from 'rxjs'
+import {ErrorOutlineIcon} from '@sanity/icons'
 import {Card, Dialog, Flex, Inline, Spinner, Stack, Text, TextInput} from '@sanity/ui'
 import {PatchEvent, set, useProjectId, ObjectInputProps, useDataset} from 'sanity'
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
-
-import DialogHeader from './DialogHeader'
-import {ErrorOutlineIcon} from '@sanity/icons'
-import File from './File'
-import InfiniteScroll from 'react-infinite-scroll-component'
 import PhotoAlbum from 'react-photo-album'
-import {Search} from './ShopifyAssetInput.styled'
+import InfiniteScroll from 'react-infinite-scroll-component'
+
 import {search} from '../datastores/shopify'
+import type {Asset, PageInfo, ShopifyAPIResponse, ShopifyFile} from '../types'
+import DialogHeader from './DialogHeader'
+import File from './File'
+import {Search} from './ShopifyAssetInput.styled'
 
 const RESULTS_PER_PAGE = 42
 const PHOTO_SPACING = 2

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1,5 +1,5 @@
-import React, {CSSProperties, useCallback, useEffect, MouseEvent} from 'react'
-import videojs, {VideoJsPlayer} from 'video.js'
+import React, {type CSSProperties, type MouseEvent, useCallback, useEffect} from 'react'
+import videojs, {type VideoJsPlayer} from 'video.js'
 
 type PlayerKind = 'player' | 'diff'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import {ObjectSchemaType} from 'sanity'
+import type {ObjectSchemaType} from 'sanity'
 
 export interface PluginConfig {
   /**


### PR DESCRIPTION
This isn't a big deal, but we tend to sort imports by type:

1. Node built-ins
2. npm modules
3. Local modules, by depth (eg the "closest" modules to the current module last)

I also added some `type` keywords where applicable (it _sometimes_ helps bundlers/typescript do tree-shaking more efficiently)