### PR TITLE
feat: strict schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,45 +14,45 @@ npm install sanity-plugin-shopify-assets
 
 Add it as a plugin in sanity.config.ts (or .js):
 
-```
- import {defineConfig} from 'sanity'
- import {shopifyAssets} from 'sanity-plugin-shopify-assets'
+```ts
+import {defineConfig} from 'sanity'
+import {shopifyAssets} from 'sanity-plugin-shopify-assets'
 
- export const defineConfig({
-     //...
-     plugins: [
-         shopifyAssets({
-            shopifyDomain: '*.myshopify.com'
-         })
-     ]
- })
+export const defineConfig({
+    //...
+    plugins: [
+        shopifyAssets({
+          shopifyDomain: '*.myshopify.com'
+        })
+    ]
+})
 ```
 
 Simply update the `shopifyDomain` to your store URL. You'll need to install the [Sanity Connect](https://www.sanity.io/docs/sanity-connect-for-shopify) app on your store to handle authorisation. You'll need to ensure the Liquid sync option is enabled within the Sanity Connect app.
 
 Then you can enable the asset selector on a field:
 
-```
+```ts
 import {defineType, defineField} from 'sanity'
 
 export const myDocumentSchema = defineType({
-  type: "document",
-  name: "article",
+  type: 'document',
+  name: 'article',
   fields: [
     defineField({
-      type: "shopify.asset",
-      name: "shopifyAsset",
+      type: 'shopify.asset',
+      name: 'shopifyAsset',
     }),
-  ]
+  ],
 })
 ```
 
 It's also possible to define the Shopify domain on the field level, which allows you to retrieve assets from different stores. Each store must be connected to your Sanity project via the Sanity Connect app. In order to do this, simply declare the `shopifyDomain` on the field:
 
-```
+```ts
 defineField({
-  type: "shopify.asset",
-  name: "shopifyAsset",
+  type: 'shopify.asset',
+  name: 'shopifyAsset',
   options: {
     shopifyDomain: '*.myshopify.com'
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
+import {definePlugin, type ObjectDefinition} from 'sanity'
 import {shopifyAssetSchema} from './schema/shopifyAssetSchema'
-import {definePlugin, ObjectDefinition} from 'sanity'
-import {PluginConfig} from './types'
+import {shopifyAssetPreviewSchema} from './schema/shopifyAssetPreviewSchema'
+import {shopifyAssetMetadataSchema} from './schema/shopifyAssetMetadataSchema'
+import type {PluginConfig} from './types'
 
 export * from './types'
 
@@ -25,7 +27,7 @@ export const shopifyAssets = definePlugin<PluginConfig>((config) => {
   return {
     name: 'shopify-asset-schema',
     schema: {
-      types: [shopifyAssetSchema(config)],
+      types: [shopifyAssetPreviewSchema, shopifyAssetMetadataSchema, shopifyAssetSchema(config)],
     },
   }
 })

--- a/src/schema/shopifyAssetMetadataSchema.ts
+++ b/src/schema/shopifyAssetMetadataSchema.ts
@@ -1,0 +1,34 @@
+import {defineField, defineType} from 'sanity'
+
+export const shopifyAssetMetadataSchema = defineType({
+  type: 'object',
+  name: 'shopify.assetMetadata',
+  title: 'Asset metadata',
+  fields: [
+    defineField({
+      type: 'string',
+      name: 'alt',
+      title: 'Alternative text',
+    }),
+    defineField({
+      type: 'number',
+      name: 'duration',
+      title: 'Duration',
+    }),
+    defineField({
+      type: 'number',
+      name: 'fileSize',
+      title: 'File size',
+    }),
+    defineField({
+      type: 'number',
+      name: 'height',
+      title: 'Height',
+    }),
+    defineField({
+      type: 'number',
+      name: 'width',
+      title: 'Width',
+    }),
+  ],
+})

--- a/src/schema/shopifyAssetPreviewSchema.ts
+++ b/src/schema/shopifyAssetPreviewSchema.ts
@@ -1,0 +1,24 @@
+import {defineField, defineType} from 'sanity'
+
+export const shopifyAssetPreviewSchema = defineType({
+  type: 'object',
+  name: 'shopify.assetPreview',
+  title: 'Asset preview',
+  fields: [
+    defineField({
+      type: 'number',
+      name: 'height',
+      title: 'Height',
+    }),
+    defineField({
+      type: 'number',
+      name: 'width',
+      title: 'Width',
+    }),
+    defineField({
+      type: 'url',
+      name: 'url',
+      title: 'URL',
+    }),
+  ],
+})

--- a/src/schema/shopifyAssetSchema.ts
+++ b/src/schema/shopifyAssetSchema.ts
@@ -28,62 +28,32 @@ export const shopifyAssetSchema = (config: ObjectConfig) => {
       defineField({
         type: 'string',
         name: 'filename',
+        title: 'Filename',
       }),
       defineField({
         type: 'string',
         name: 'id',
+        title: 'ID',
       }),
       defineField({
-        type: 'object',
+        type: 'shopify.assetMetadata',
         name: 'meta',
-        fields: [
-          defineField({
-            type: 'string',
-            name: 'alt',
-          }),
-          defineField({
-            type: 'number',
-            name: 'duration',
-          }),
-          defineField({
-            type: 'number',
-            name: 'fileSize',
-          }),
-          defineField({
-            type: 'number',
-            name: 'height',
-          }),
-          defineField({
-            type: 'number',
-            name: 'width',
-          }),
-        ],
+        title: 'Metadata',
       }),
       defineField({
-        type: 'object',
+        type: 'shopify.assetPreview',
         name: 'preview',
-        fields: [
-          defineField({
-            type: 'number',
-            name: 'height',
-          }),
-          defineField({
-            type: 'number',
-            name: 'width',
-          }),
-          defineField({
-            type: 'url',
-            name: 'url',
-          }),
-        ],
+        title: 'Preview',
       }),
       defineField({
         type: 'string',
         name: 'type',
+        title: 'Type',
       }),
       defineField({
         type: 'url',
         name: 'url',
+        title: 'URL',
       }),
     ],
     ...({


### PR DESCRIPTION
Currently, the schema definitions use inline objects for the asset metadata and asset preview fields. This is incompatible with "strict schemas", which prevents a GraphQL API from being deployed.

This PR moves those types to separate, named object types (`shopify.assetMetadata` and `shopify.assetPreview`).

I'm not super familiar with how data flows in these shopify scenarios - is data imported or created in-studio? If imported, we should check what the source puts into the `meta._type` and `preview._type` fields - they should (preferably) be `shopify.assetMetadata` and `shopify.assetPreview`, or alternatively not be present.
