### PR TITLE
fix: add Bearer token authentication for improved reliability

### DIFF
--- a/src/components/ShopifyAssetPicker.tsx
+++ b/src/components/ShopifyAssetPicker.tsx
@@ -1,7 +1,7 @@
 import {BehaviorSubject, Subscription} from 'rxjs'
 import {ErrorOutlineIcon} from '@sanity/icons'
 import {Card, Dialog, Flex, Inline, Spinner, Stack, Text, TextInput} from '@sanity/ui'
-import {PatchEvent, set, useProjectId, ObjectInputProps, useDataset} from 'sanity'
+import {PatchEvent, set, useProjectId, ObjectInputProps, useDataset, useClient} from 'sanity'
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import PhotoAlbum from 'react-photo-album'
 import InfiniteScroll from 'react-infinite-scroll-component'
@@ -26,6 +26,8 @@ export default function ShopifyAssetPicker(props: AssetPickerProps) {
   const {isOpen, onClose, shopifyDomain, onChange, schemaType, value} = props
   const projectId = useProjectId()
   const dataset = useDataset()
+  const client = useClient({apiVersion: '2021-06-07'})
+  const token = client.config().token
 
   const [error, setError] = useState('')
   const [query, setQuery] = useState('')
@@ -48,6 +50,7 @@ export default function ShopifyAssetPicker(props: AssetPickerProps) {
       query: searchSubject$,
       cursor: cursorSubject$,
       resultsPerPage: RESULTS_PER_PAGE,
+      token,
     }).subscribe({
       next: (results: ShopifyAPIResponse) => {
         setSearchResults((prevResults) => [...prevResults, ...results.assets])
@@ -57,14 +60,14 @@ export default function ShopifyAssetPicker(props: AssetPickerProps) {
       error: (err) => {
         setError(
           `${
-            err.response.data.message || err.message || 'An error occurred'
+            err.response?.data?.message || err.message || 'An error occurred'
           } - check plugin configuration`
         )
       },
     })
 
     return () => searchSubscription.unsubscribe()
-  }, [searchSubject$, cursorSubject$, shopifyDomain, projectId, dataset])
+  }, [searchSubject$, cursorSubject$, shopifyDomain, projectId, dataset, token])
 
   const handleSearchTermChanged = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/datastores/shopify.ts
+++ b/src/datastores/shopify.ts
@@ -13,6 +13,7 @@ interface fetchProps {
   query: SearchSubject
   cursor: CursorSubject
   resultsPerPage: number
+  token?: string
 }
 
 interface searchProps extends Omit<fetchProps, 'query' | 'cursor'> {
@@ -24,7 +25,7 @@ interface listProps extends Omit<fetchProps, 'query' | 'cursor'> {
 }
 
 const fetchSearch = (props: searchProps): Observable<any> => {
-  const {projectId, dataset, shop, query, cursor, resultsPerPage} = props
+  const {projectId, dataset, shop, query, cursor, resultsPerPage, token} = props
 
   return defer(() => {
     return axios.get(
@@ -34,13 +35,16 @@ const fetchSearch = (props: searchProps): Observable<any> => {
       {
         withCredentials: true,
         method: 'GET',
+        headers: token ? {
+          Authorization: `Bearer ${token}`
+        } : {}
       }
     )
   }).pipe(map((result) => result.data))
 }
 
 const fetchList = (props: listProps): Observable<any> => {
-  const {projectId, dataset, shop, cursor, resultsPerPage} = props
+  const {projectId, dataset, shop, cursor, resultsPerPage, token} = props
 
   return defer(() =>
     axios.get(
@@ -50,13 +54,16 @@ const fetchList = (props: listProps): Observable<any> => {
       {
         withCredentials: true,
         method: 'GET',
+        headers: token ? {
+          Authorization: `Bearer ${token}`
+        } : {}
       }
     )
   ).pipe(map((result) => result.data))
 }
 
 export const search = (props: fetchProps): Observable<any> => {
-  const {projectId, dataset, shop, query, cursor, resultsPerPage} = props
+  const {projectId, dataset, shop, query, cursor, resultsPerPage, token} = props
 
   return concat(
     query.pipe(
@@ -65,11 +72,11 @@ export const search = (props: fetchProps): Observable<any> => {
       distinctUntilChanged(),
       switchMap(([q, c]) => {
         if (q) {
-          return fetchSearch({projectId, dataset, shop, query: q, cursor: c, resultsPerPage}).pipe(
+          return fetchSearch({projectId, dataset, shop, query: q, cursor: c, resultsPerPage, token}).pipe(
             distinctUntilChanged()
           )
         }
-        return fetchList({projectId, dataset, shop, cursor: c, resultsPerPage})
+        return fetchList({projectId, dataset, shop, cursor: c, resultsPerPage, token})
       })
     )
   )


### PR DESCRIPTION
## Problem

The plugin currently relies solely on browser cookies (`withCredentials: true`) for authentication, which fails in several common scenarios:

- **Third-party cookie restrictions**: Safari, Chrome in incognito mode, and browsers with strict privacy settings block third-party cookies
- **Users without valid session cookies**: Authentication fails even when users are logged into Sanity Studio
- **Strict SameSite cookie policies**: Modern browsers enforce stricter cookie policies that can prevent cookie-based auth

This causes "Authorization required" errors for some users, making the asset picker completely unusable despite being authenticated in Sanity Studio. Other Sanity API calls in the Studio work fine because they use Bearer token authentication.

## Solution

This PR adds **Bearer token authentication** alongside the existing cookie-based authentication for maximum compatibility:

1. Retrieve the auth token using `useClient().config().token` in the component
2. Pass the token to the API request functions  
3. Add `Authorization: Bearer ${token}` header to all axios requests
4. Maintain `withCredentials: true` for backward compatibility

## Changes

**`src/datastores/shopify.ts`**:
- Added optional `token?: string` parameter to `fetchProps` interface
- Updated `fetchSearch()` to include Bearer token in request headers
- Updated `fetchList()` to include Bearer token in request headers
- Modified `search()` to pass token through to both functions

**`src/components/ShopifyAssetPicker.tsx`**:
- Added `useClient` import from Sanity
- Retrieved auth token using `client.config().token`
- Passed token to `search()` function
- Improved error handling with optional chaining (`err.response?.data?.message`)
- Added token to useEffect dependencies

## Testing

- ✅ Build succeeds without TypeScript errors
- ✅ Plugin works for users with valid session cookies (existing behavior)
- ✅ Plugin now works for users without session cookies (new behavior)
- ✅ Backward compatible with existing implementations
- ✅ Uses the same authentication method as other Sanity Studio API calls

## Impact

This fix resolves authentication errors where the asset picker showed errors despite users being properly authenticated in Sanity Studio. The plugin will now work reliably across all browsers and authentication scenarios.

## Related Issues

This addresses the authentication inconsistency where the plugin uses a different auth mechanism than the rest of Sanity Studio, causing failures in cookie-restricted environments.