### PR TITLE
fix(deps): allow studio v5 in peer deps ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
       },
       "peerDependencies": {
         "react": "^18.3 || ^19",
-        "sanity": "^3 || ^4.0.0-0",
+        "sanity": "^3 || ^4.0.0-0 || ^5.0.0",
         "styled-components": "^6"
       }
     },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "peerDependencies": {
     "react": "^18.3 || ^19",
-    "sanity": "^3 || ^4.0.0-0",
+    "sanity": "^3 || ^4.0.0-0 || ^5.0.0",
     "styled-components": "^6"
   },
   "engines": {


### PR DESCRIPTION
### Description
This pull request updates the peer dependencies to support Sanity version 5.x, allowing the plugin to work with the latest major version of Sanity Studio while maintaining backward compatibility with versions 3.x and 4.x.